### PR TITLE
Fix: #47. Use ruff in pre-commit.

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -15,7 +15,7 @@ jobs:
   pre-commit:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    container: python:3.9
+    container: python:3.10
     steps:
       - uses: actions/checkout@v2
 
@@ -26,7 +26,7 @@ jobs:
           pwd
           ls -la
           id
-          git config --global --add safe.directory $PWD
+          git config --global --add safe.directory "${PWD}"
           pre-commit install
           # Skill checks requiring docker.
           SKIP=shellcheck pre-commit run -a
@@ -56,7 +56,11 @@ jobs:
           #   you can re-enable it if you align your local isort with
           #   the one in the super-linter image.
           VALIDATE_PYTHON_ISORT: false
+          # We are not currently enforcing type hints. TODO: do we want to?
+          VALIDATE_PYTHON_MYPY: false
           VALIDATE_XML: false
+          # Since we use SparQL, disable SQLFluff validation to avoid false positives.
+          VALIDATE_SQLFLUFF: false
           VALIDATE_NATURAL_LANGUAGE: false
           PYTHON_PYLINT_CONFIG_FILE: .pylintrc
           LINTER_RULES_PATH: '.'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup.
         run: |
-          apt-get update && apt-get install -y docker-ce-cli
+          sudo apt-get update && sudo apt-get install -y docker-ce-cli
       - name: Run tests.
         run: |
           docker compose run --rm test

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -38,12 +38,12 @@ jobs:
       - uses: actions/checkout@v3
       - name: Setup.
         run: |
-          pip install docker-compose
+          apt-get update && apt-get install -y docker-ce-cli
       - name: Run tests.
         run: |
-          docker-compose run --rm test
+          docker compose run --rm test
       - name: Cleanup
-        run: docker-compose down && docker-compose rm --force
+        run: docker compose down && docker compose rm --force
 
   publish:
     # Publish to PyPI. See https://docs.pypi.org/trusted-publishers/using-a-publisher/

--- a/.github/workflows/sast.yml
+++ b/.github/workflows/sast.yml
@@ -26,7 +26,7 @@ jobs:
       run: |
         echo UID=$(id -u) >> .env
         docker run --rm --user=$(id -u) \
-          -v $PWD:/code \
+          -v "${PWD}:/code" \
           -w /code \
           -e MAVEN_OPTS=" -ntp " \
           -e RUN_OWASP_DEPENDENCY_CHECK=false \

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -17,6 +17,12 @@ repos:
     -   id: check-yaml
         args: [--allow-multiple-documents]
     -   id: check-added-large-files
+- repo: https://github.com/astral-sh/ruff-pre-commit
+  rev: v0.5.1
+  hooks:
+    - id: ruff
+      args: [ --fix ]
+    - id: ruff-format
 - repo: https://github.com/myint/autoflake
   rev: v2.2.1
   hooks:
@@ -25,28 +31,6 @@ repos:
         - --in-place
         - --remove-unused-variables
         - --remove-all-unused-imports
--   repo: https://github.com/psf/black
-    rev: 23.12.0
-    hooks:
-    -   id: black
-- repo: https://github.com/pycqa/isort
-  rev: 5.13.2
-  hooks:
-    - id: isort
-      name: isort (python)
-      # Use black profile for isort to avoid conflicts
-      #   see https://github.com/PyCQA/isort/issues/1518
-      args: ["--profile", "black"]
-    - id: isort
-      name: isort (cython)
-      types: [cython]
-    - id: isort
-      name: isort (pyi)
-      types: [pyi]
-- repo: https://github.com/PyCQA/flake8
-  rev: 6.1.0
-  hooks:
-  - id: flake8
 - repo: https://github.com/PyCQA/bandit
   rev: 1.7.6
   hooks:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,1 @@
 FROM ghcr.io/par-tec/ml-playground:py310-spacy-20231120-18-a6ad1df
-RUN apt-get -y update && \
-    apt-get -y install python3-pip
-
-RUN python3 -m pip install tox

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -15,6 +15,7 @@ services:
     entrypoint: [sleep, infinity]
   test:
     <<: *base
+    user: root
     entrypoint: [tox]
   model:
     <<: *base

--- a/esco/vector.py
+++ b/esco/vector.py
@@ -71,8 +71,8 @@ class VectorDB:
         points = Batch(
             ids=[x.split("/")[-1] for x in skills.index.values],
             payloads=[
-                {"metadata": {"label": l, "uri": i}, "page_content": t}
-                for t, l, i in zip(
+                {"metadata": {"label": label, "uri": i}, "page_content": t}
+                for t, label, i in zip(
                     skills.text.values, skills.label.values, skills.index.values
                 )
             ],

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,7 +14,7 @@ jupyter
 # Further requirements file for running models
 langchain==0.1.0
 langchain-community==0.0.12
-qdrant-client==1.7.0
+qdrant-client==1.10.1
 nltk==3.8.1
 tiktoken==0.5.2
 

--- a/tests/test_vector.py
+++ b/tests/test_vector.py
@@ -23,8 +23,8 @@ models = {
     },
 }
 documents = [
-    Document(page_content=t, metadata={"label": l, "uri": i})
-    for t, l, i in zip(skills.text.values, skills.label.values, skills.index.values)
+    Document(page_content=t, metadata={"label": label, "uri": i})
+    for t, label, i in zip(skills.text.values, skills.label.values, skills.index.values)
 ]
 
 


### PR DESCRIPTION
## This PR

- use ruff instead of black, isort, flake8
- partial fixes on the CI

## This is done

- ruff is faster and does the same things